### PR TITLE
less undefined/nullable for required (non-nullable backend fields)

### DIFF
--- a/.snapshot/withLegacyUndefineGeneration/models.ts
+++ b/.snapshot/withLegacyUndefineGeneration/models.ts
@@ -34,16 +34,16 @@ interface ICategoryMotorsDtoBaseInterface {
 export type ICategoryMotorsDto = ICategoryMotorsDtoBaseInterface & ICategory;
 
 export interface IProduct {
-    categories: ICategoryUnion[];
+    categories: $types.TypeOrUndefined<ICategoryUnion[]>;
     category: $types.TypeOrUndefined<ICategoryUnion>;
     colors: $types.TypeOrUndefined<string[]>;
     expireDate: $types.TypeOrUndefined<string>;
     externalId: $types.TypeOrUndefinedNullable<string>;
     id: $types.TypeOrUndefined<string>;
-    modifyDates: string[];
+    modifyDates: $types.TypeOrUndefined<string[]>;
     name: $types.TypeOrUndefinedNullable<string>;
-    parentProduct: IProduct;
-    status: ProductStatus;
+    parentProduct: $types.TypeOrUndefinedNullable<IProduct>;
+    status: $types.TypeOrUndefined<ProductStatus>;
 }
 
 export interface IProductIdentityDTO {
@@ -111,7 +111,7 @@ export class Category {
         this.type = dto.type;
     }
 
-    public static toDTO(model: $types.PublicFields<Category>): ICategory {
+    public static toDTO(model: Partial<Category>): ICategory {
         return {
             name: model.name,
             type: model.type,
@@ -135,7 +135,7 @@ export class CategoryElectronicsDto {
         this.type = dto.type;
     }
 
-    public static toDTO(model: $types.PublicFields<CategoryElectronicsDto>): ICategoryElectronicsDto {
+    public static toDTO(model: Partial<CategoryElectronicsDto>): ICategoryElectronicsDto {
         return {
             syntheticTest: model.syntheticTest,
             name: model.name,
@@ -160,7 +160,7 @@ export class CategoryMotorsDto {
         this.type = dto.type;
     }
 
-    public static toDTO(model: $types.PublicFields<CategoryMotorsDto>): ICategoryMotorsDto {
+    public static toDTO(model: Partial<CategoryMotorsDto>): ICategoryMotorsDto {
         return {
             volume: model.volume,
             name: model.name,
@@ -182,34 +182,34 @@ export class Product {
     public id: $types.TypeOrUndefined<Guid>;
     public modifyDates: Date[];
     public name: $types.TypeOrUndefinedNullable<string>;
-    public parentProduct: Product;
-    public status: ProductStatus;
+    public parentProduct: $types.TypeOrUndefinedNullable<Product>;
+    public status: $types.TypeOrUndefined<ProductStatus>;
     private __product!: string;
 
     protected constructor(dto: IProduct) {
-        this.categories = dto.categories.map(x => CategoryUnionClass.fromDTO(x));
+        this.categories = dto.categories ? dto.categories.map(x => CategoryUnionClass.fromDTO(x)) : [];
         this.category = dto.category ? CategoryUnionClass.fromDTO(dto.category) : undefined;
         this.colors = dto.colors ? dto.colors : [];
         this.expireDate = toDateIn(dto.expireDate);
         this.externalId = dto.externalId ? new Guid(dto.externalId) : null;
         this.id = new Guid(dto.id);
-        this.modifyDates = dto.modifyDates.map(toDateIn);
+        this.modifyDates = dto.modifyDates ? dto.modifyDates.map(toDateIn) : [];
         this.name = dto.name;
-        this.parentProduct = Product.fromDTO(dto.parentProduct);
+        this.parentProduct = dto.parentProduct ? Product.fromDTO(dto.parentProduct) : undefined;
         this.status = dto.status;
     }
 
-    public static toDTO(model: $types.PublicFields<Product>): IProduct {
+    public static toDTO(model: Partial<Product>): IProduct {
         return {
-            categories: model.categories.map(x => CategoryUnionClass.toDTO(x)),
+            categories: model.categories ? model.categories.map(x => CategoryUnionClass.toDTO(x)) : undefined,
             category: model.category ? CategoryUnionClass.toDTO(model.category) : undefined,
             colors: model.colors,
             expireDate: toDateOut(model.expireDate),
             externalId: model.externalId ? model.externalId.toString() : null,
             id: model.id ? model.id.toString() : Guid.empty.toString(),
-            modifyDates: model.modifyDates.map(toDateOut),
+            modifyDates: model.modifyDates ? model.modifyDates.map(toDateOut) : undefined,
             name: model.name,
-            parentProduct: Product.toDTO(model.parentProduct),
+            parentProduct: model.parentProduct ? Product.toDTO(model.parentProduct) : undefined,
             status: model.status,
         };
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GenGen
 
- [![NPM version](https://img.shields.io/npm/v/@luxbss/gengen.svg)](https://www.npmjs.com/package/@luxbss/gengen) [![license](https://img.shields.io/github/license/luxoft/gengen)](https://github.com/Luxoft/gengen/blob/master/LICENSE.txt) [![GitHub contributors](https://img.shields.io/github/contributors/luxoft/gengen)](https://github.com/Luxoft/gengen/graphs/contributors/)
+[![NPM version](https://img.shields.io/npm/v/@luxbss/gengen.svg)](https://www.npmjs.com/package/@luxbss/gengen) [![license](https://img.shields.io/github/license/luxoft/gengen)](https://github.com/Luxoft/gengen/blob/master/LICENSE.txt) [![GitHub contributors](https://img.shields.io/github/contributors/luxoft/gengen)](https://github.com/Luxoft/gengen/graphs/contributors/)
 
 This tool generates models and [Angular](https://angular.io/) services based on generated [Swagger JSON](https://swagger.io/specification/).
 
@@ -45,18 +45,18 @@ gengen g --all
 
 ### Options
 
-| Option                 | Description                                                                                | Type    | Default value                                  |
-| ---------------------- | ------------------------------------------------------------------------------------------ | ------- | ---------------------------------------------- |
-| **all**                | Generate all                                                                               | boolean | false                                          |
-| **url**                | Location of swagger.json                                                                   | string  | https://localhost:5001/swagger/v1/swagger.json |
-| **file**               | Local path to swagger.json                                                                 | string  |                                                |
-| **output**             | Output directory                                                                           | string  | ./src/generated                                |
-| **configOutput**       | Output directory using in 'Generate a part of API' scenario                                | string  | ./.generated                                   |
-| **aliasName**          | Specify prefix for generated filenames. [more info](#aliasName)                            | string  |                                                |
-| **withRequestOptions** | Allows to pass http request options to generated methods. [more info](#withRequestOptions) | boolean | false                                     |
-| **utilsRelativePath** | Relative path to utils files. It may be useful when you have multiple generation sources | string |                                      |
-| **unstrictId** | Disable converting 'id' properties to strong Guid type. [more info](#unstrictId) | boolean | false                                     |
-|                        |
+| Option                           | Description                                                                                                          | Type    | Default value                                  |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------- |
+| **all**                          | Generate all                                                                                                         | boolean | false                                          |
+| **url**                          | Location of swagger.json                                                                                             | string  | https://localhost:5001/swagger/v1/swagger.json |
+| **file**                         | Local path to swagger.json                                                                                           | string  |                                                |
+| **output**                       | Output directory                                                                                                     | string  | ./src/generated                                |
+| **configOutput**                 | Output directory using in 'Generate a part of API' scenario                                                          | string  | ./.generated                                   |
+| **aliasName**                    | Specify prefix for generated filenames. [more info](#aliasName)                                                      | string  |                                                |
+| **withRequestOptions**           | Allows to pass http request options to generated methods. [more info](#withRequestOptions)                           | boolean | false                                          |
+| **utilsRelativePath**            | Relative path to utils files. It may be useful when you have multiple generation sources                             | string  |                                                |
+| **unstrictId**                   | Disable converting 'id' properties to strong Guid type. [more info](#unstrictId)                                     | boolean | false                                          |
+| **withLegacyUndefineGeneration** | Allow enabling the "previous" style generation with many undefined types. [more info](#withLegacyUndefineGeneration) | boolean | false                                          |
 
 ### Option details
 
@@ -110,9 +110,8 @@ export class ExampleService extends BaseHttpService {
     // ...
 }
 
-@Component(
-    // ...
-)
+@Component()
+// ...
 export class MyComponent {
     constructor(private exampleService: ExampleService) {
         this.exampleService.methodName({
@@ -143,6 +142,44 @@ public static fromDTO(dto: IProduct): Product {
     // ...
 }
 ```
+
+#### withLegacyUndefineGeneration
+
+From version 1.3, GenGen supports the [required properties](https://swagger.io/docs/specification/v3_0/data-models/data-types/#required-properties) option from types, which indicates that a field is required on the backend and mandatory (not-null) in the type. For `required` fields, GenGen uses non-null and non-undefined types. Additionally, the generation of the toDto methods has been changed to use `PublicFields<XXX>` instead of `Partial<XXX>`.
+
+Example:
+
+```ts
+// with withLegacyUndefineGeneration
+public static toDTO(model: Partial<Product>): IProduct {
+    return {
+        // ...
+        id: model.obj ? ObjDto.toDTO(model.obj) : undefined,
+        // ...
+    };
+}
+
+// default, all field in model required
+public static toDTO(model: PublicFields<Product>): IProduct {
+    return {
+        // ...
+        id: ObjDto.toDTO(model.obj),
+        // ...
+    };
+}
+```
+
+To enable all power of this behavior you need to customize generation your OpenAPI specification, for Swashbuckle.AspNetCore it can be done with the next [options](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2036):
+
+```csharp
+serviceCollection.AddSwaggerGen(builder =>
+{
+  builder.SupportNonNullableReferenceTypes();
+  builder.NonNullableReferenceTypesAsRequired();
+});
+```
+
+However, if you want to use the previous generation for some reason, you can enable it with the `withLegacyUndefineGeneration` option.
 
 # License and copyright
 

--- a/__tests__/generators/utils/TypeSerializer.spec.ts
+++ b/__tests__/generators/utils/TypeSerializer.spec.ts
@@ -63,18 +63,49 @@ describe('TypeSerializer tests', () => {
         });
     });
 
-    test('fromInterfaceProperty should return optional dtoType', () => {
+    test('fromInterfaceProperty without isRequired should return optional dtoType', () => {
         // Arrange
         // Act
         const result = TypeSerializer.fromInterfaceProperty({
             dtoType: 'MyDtoType',
             isCollection: false,
             isNullable: false,
-            name: 'interface property name'
+            name: 'interface property name',
+            isRequired: false
         }).toString();
 
         // Assert
         expect(result).toEqual('$types.TypeOrUndefined<MyDtoType>');
+    });
+
+    test('fromInterfaceProperty with isRequired should return dtoType', () => {
+        // Arrange
+        // Act
+        const result = TypeSerializer.fromInterfaceProperty({
+            dtoType: 'MyDtoType',
+            isCollection: false,
+            isNullable: false,
+            name: 'interface property name',
+            isRequired: true
+        }).toString();
+
+        // Assert
+        expect(result).toEqual('MyDtoType');
+    });
+
+    test('fromInterfaceProperty with isRequired but isNullable should return dtoType', () => {
+        // Arrange
+        // Act
+        const result = TypeSerializer.fromInterfaceProperty({
+            dtoType: 'MyDtoType',
+            isCollection: false,
+            isNullable: true,
+            name: 'interface property name',
+            isRequired: true
+        }).toString();
+
+        // Assert
+        expect(result).toEqual('MyDtoType');
     });
 
     test('fromTypeName should return optional type', () => {

--- a/e2e/e2e.ts
+++ b/e2e/e2e.ts
@@ -11,6 +11,11 @@ async function main() {
     snapshotter('./.snapshot/all/models.ts', './.output/all/models.ts', 'Models');
     snapshotter('./.snapshot/all/services.ts', './.output/all/services.ts', 'Services without RequestOptions');
     snapshotter('./.snapshot/withRequestOptions/services.ts', './.output/withRequestOptions/services.ts', 'Services with RequestOptions');
+    snapshotter(
+        './.snapshot/withLegacyUndefineGeneration/models.ts',
+        './.output/withLegacyUndefineGeneration/models.ts',
+        'Models with LegacyUndefineGeneration'
+    );
 }
 
 async function snapshotter(pathA: string, pathB: string, name: string) {

--- a/libs/date-converters.ts
+++ b/libs/date-converters.ts
@@ -1,21 +1,21 @@
-import type { TypeOrUndefined, TypeOrUndefinedNullable } from './types';
+import type { TypeOrUndefinedNullable } from './types';
 const HOUR_COEFF = 3600000;
 const MINUTS_IN_HOUR = 60;
 
-export function toDateOut(value: TypeOrUndefinedNullable<Date>): TypeOrUndefined<string> {
+export function toDateOut<T extends TypeOrUndefinedNullable<Date>>(value: T): T extends Date ? string : undefined {
     if (!value) {
-        return undefined;
+        return undefined as never;
     }
 
-    return dateOut(value).toISOString();
+    return dateOut(value).toISOString() as never;
 }
 
-export function toDateIn(value: TypeOrUndefinedNullable<string>): TypeOrUndefined<Date> {
+export function toDateIn<T extends TypeOrUndefinedNullable<string>>(value: T): T extends string ? Date : undefined {
     if (!value) {
-        return undefined;
+        return undefined as never;
     }
 
-    return dateIn(new Date(value));
+    return dateIn(new Date(value)) as never;
 }
 
 function dateOut(value: Date): Date {

--- a/libs/types.ts
+++ b/libs/types.ts
@@ -1,3 +1,4 @@
 export type TypeOrUndefined<T> = T | undefined;
 export type TypeOrUndefinedNullable<T> = T | undefined | null;
+export type PublicFields<T> = Pick<T, keyof T>;
 export type DTOIdentityType = { id: TypeOrUndefined<string> };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxbss/gengen",
-    "version": "1.2.9",
+    "version": "1.3.0",
     "description": "Tool for generating models and Angular services based on OpenAPIs and Swagger's JSON",
     "bin": {
         "gengen": "./bin/index.js"
@@ -12,8 +12,9 @@
         "g:selected": "node ./bin/index.js g --file=./swagger.json --output=./.output/selected",
         "g": "node ./bin/index.js g --all --file=./swagger.json --output=./.output/all",
         "g:withRequestOptions": "node ./bin/index.js g --all --file=./swagger.json --output=./.output/withRequestOptions --withRequestOptions",
+        "g:withLegacyUndefineGeneration": "node ./bin/index.js g --all --file=./swagger.json --output=./.output/withLegacyUndefineGeneration --withLegacyUndefineGeneration",
         "g:alias": "node ./bin/index.js g --file=./swagger.json --aliasName alias --output=./.output/selected",
-        "e2e": "npm run g && npm run g:withRequestOptions && ts-node ./e2e/e2e.ts",
+        "e2e": "npm run g && npm run g:withRequestOptions && npm run g:withLegacyUndefineGeneration && ts-node ./e2e/e2e.ts",
         "g:b": "npm run build && npm run g",
         "test": "jest",
         "test:w": "jest --watch",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -32,6 +32,7 @@ program
     .option('--all')
     .option('--withRequestOptions')
     .option('--unstrictId')
+    .option('--withLegacyUndefineGeneration')
     .description('Generates models and services')
     .action(async (params) => {
         const options = getOptions(params);

--- a/src/generators/models-generator/ObjectGenerator.ts
+++ b/src/generators/models-generator/ObjectGenerator.ts
@@ -14,6 +14,7 @@ import { FROM_DTO_METHOD, TO_DTO_METHOD } from '../ModelsGenerator';
 import { ARRAY_STRING, NULL_STRING, UNDEFINED_STRING } from '../utils/consts';
 import { TypeSerializer } from '../utils/TypeSerializer';
 import { PropertiesGenerator } from './PropertiesGenerator';
+import { publicFields } from '../utils/typeOrUndefined';
 
 export class ObjectGenerator {
     constructor(
@@ -45,7 +46,7 @@ export class ObjectGenerator {
                     scope: Scope.Public,
                     isStatic: true,
                     name: TO_DTO_METHOD,
-                    parameters: [{ name: 'model', type: z.name }],
+                    parameters: [{ name: 'model', type: publicFields(z.name) }],
                     returnType: z.dtoType,
                     statements: (x) => {
                         x.writeLine('return {');

--- a/src/generators/models-generator/ObjectGenerator.ts
+++ b/src/generators/models-generator/ObjectGenerator.ts
@@ -46,7 +46,7 @@ export class ObjectGenerator {
                     scope: Scope.Public,
                     isStatic: true,
                     name: TO_DTO_METHOD,
-                    parameters: [{ name: 'model', type: publicFields(z.name) }],
+                    parameters: [{ name: 'model', type: this.getToDtoArgumentType(z.name) }],
                     returnType: z.dtoType,
                     statements: (x) => {
                         x.writeLine('return {');
@@ -69,6 +69,10 @@ export class ObjectGenerator {
                 }
             ]
         }));
+    }
+
+    protected getToDtoArgumentType(originType: string): string {
+        return publicFields(originType);
     }
 
     private getObjectProperties(objectModel: ObjectModel, objects: ObjectModel[]): PropertyDeclarationStructure[] {

--- a/src/generators/models-generator/ObjectGenerator.ts
+++ b/src/generators/models-generator/ObjectGenerator.ts
@@ -1,4 +1,11 @@
-import { ClassDeclarationStructure, CodeBlockWriter, PropertyDeclarationStructure, Scope, StructureKind } from 'ts-morph';
+import {
+    ClassDeclarationStructure,
+    CodeBlockWriter,
+    ConstructorDeclarationStructure,
+    PropertyDeclarationStructure,
+    Scope,
+    StructureKind
+} from 'ts-morph';
 
 import { PropertyKind } from '../../models/kinds/PropertyKind';
 import { IExtendedObjectModel, IObjectPropertyModel, ObjectModel } from '../../models/ObjectModel';
@@ -20,12 +27,25 @@ export class ObjectGenerator {
             isExported: true,
             name: z.name,
             properties: this.getObjectProperties(z, objects),
+            ctors: [
+                {
+                    kind: StructureKind.Constructor,
+                    scope: Scope.Protected,
+                    parameters: [{ name: 'dto', type: z.dtoType }],
+                    statements: (x) => {
+                        z.properties.forEach((p) => x.writeLine(`this.${p.name} = ${this.getFromDtoPropertyInitializer(p)};`));
+                        this.printCombinedProprs(z, x, objects, (p) =>
+                            x.writeLine(`this.${p.name} = ${this.getFromDtoPropertyInitializer(p)};`)
+                        );
+                    }
+                } satisfies ConstructorDeclarationStructure
+            ],
             methods: [
                 {
                     scope: Scope.Public,
                     isStatic: true,
                     name: TO_DTO_METHOD,
-                    parameters: [{ name: 'model', type: `Partial<${z.name}>` }],
+                    parameters: [{ name: 'model', type: z.name }],
                     returnType: z.dtoType,
                     statements: (x) => {
                         x.writeLine('return {');
@@ -44,16 +64,7 @@ export class ObjectGenerator {
                     name: FROM_DTO_METHOD,
                     parameters: [{ name: 'dto', type: z.dtoType }],
                     returnType: z.name,
-                    statements: (x) => {
-                        x.writeLine(`const model = new ${z.name}();`);
-                        z.properties.forEach((p) =>
-                            x.withIndentationLevel(2, () => x.writeLine(`model.${p.name} = ${this.getFromDtoPropertyInitializer(p)};`))
-                        );
-                        this.printCombinedProprs(z, x, objects, (p) =>
-                            x.withIndentationLevel(2, () => x.writeLine(`model.${p.name} = ${this.getFromDtoPropertyInitializer(p)};`))
-                        );
-                        x.writeLine('return model;');
-                    }
+                    statements: (x) => x.writeLine(`return new ${z.name}(dto);`)
                 }
             ]
         }));
@@ -88,10 +99,11 @@ export class ObjectGenerator {
             name: objectProperty.name,
             type: new TypeSerializer({
                 type: { name: objectProperty.type },
-                isNullable: objectProperty.isNullable,
+                isNullable: !objectProperty.isRequired && objectProperty.isNullable,
+                isOptional: !objectProperty.isRequired,
                 isCollection: objectProperty.isCollection
             }).toString(),
-            initializer: objectProperty.isCollection ? ARRAY_STRING : UNDEFINED_STRING
+            initializer: undefined
         };
     }
 
@@ -101,45 +113,53 @@ export class ObjectGenerator {
         switch (property.kind) {
             case PropertyKind.Date:
                 if (property.isCollection) {
-                    return `${modelProperty} ? ${modelProperty}.map(toDateOut) : ${UNDEFINED_STRING}`;
+                    const collectionMap = `${modelProperty}.map(toDateOut)`;
+                    return property.isRequired ? collectionMap : `${modelProperty} ? ${collectionMap} : ${UNDEFINED_STRING}`;
                 }
 
                 return `toDateOut(${modelProperty})`;
 
-            case PropertyKind.Guid:
+            case PropertyKind.Guid: {
                 if (property.isCollection) {
-                    return `${modelProperty} ? ${modelProperty}.map(x => x.toString()) : ${UNDEFINED_STRING}`;
+                    const collectionMap = `${modelProperty}.map(x => x.toString())`;
+                    return property.isRequired ? collectionMap : `${modelProperty} ? ${collectionMap} : ${UNDEFINED_STRING}`;
                 }
 
-                return (
-                    `${modelProperty} ? ${modelProperty}.toString()` +
-                    ` : ${property.isNullable ? NULL_STRING : `${property.type}.empty.toString()`}`
-                );
+                const valueMap = `${modelProperty}.toString()`;
+                return property.isRequired
+                    ? valueMap
+                    : `${modelProperty} ? ${valueMap} : ${property.isNullable ? NULL_STRING : `${property.type}.empty.toString()`}`;
+            }
 
-            case PropertyKind.Identity:
+            case PropertyKind.Identity: {
                 if (property.isCollection) {
-                    return `${modelProperty} ? ${modelProperty}.map(x => ${property.type}.${TO_DTO_METHOD}(x.id)) : ${UNDEFINED_STRING}`;
+                    const collectionMap = `${modelProperty}.map(x => ${property.type}.${TO_DTO_METHOD}(x.id))`;
+                    return property.isRequired ? collectionMap : `${modelProperty} ? ${collectionMap} : ${UNDEFINED_STRING}`;
                 }
 
-                return `${modelProperty} ? ${property.type}.${TO_DTO_METHOD}(${modelProperty}.id) : ${UNDEFINED_STRING}`;
+                const valueMap = `${property.type}.${TO_DTO_METHOD}(${modelProperty}.id)`;
+                return property.isRequired ? valueMap : `${modelProperty} ? ${valueMap} : ${UNDEFINED_STRING}`;
+            }
 
-            case PropertyKind.Union:
+            case PropertyKind.Union: {
                 if (property.isCollection) {
-                    return `${modelProperty} ? ${modelProperty}.map(x => ${this.nameService.getClassName(
-                        property.type
-                    )}.${TO_DTO_METHOD}(x)) : ${UNDEFINED_STRING}`;
+                    const collectionMap = `${modelProperty}.map(x => ${this.nameService.getClassName(property.type)}.${TO_DTO_METHOD}(x))`;
+                    return property.isRequired ? collectionMap : `${modelProperty} ? ${collectionMap} : ${UNDEFINED_STRING}`;
                 }
 
-                return `${modelProperty} ? ${this.nameService.getClassName(
-                    property.type
-                )}.${TO_DTO_METHOD}(${modelProperty}) : ${UNDEFINED_STRING}`;
+                const valueMap = `${this.nameService.getClassName(property.type)}.${TO_DTO_METHOD}(${modelProperty})`;
+                return property.isRequired ? valueMap : `${modelProperty} ? ${valueMap} : ${UNDEFINED_STRING}`;
+            }
 
-            case PropertyKind.Object:
+            case PropertyKind.Object: {
                 if (property.isCollection) {
-                    return `${modelProperty} ? ${modelProperty}.map(x => ${property.type}.${TO_DTO_METHOD}(x)) : ${UNDEFINED_STRING}`;
+                    const collectionMap = `${modelProperty}.map(x => ${property.type}.${TO_DTO_METHOD}(x))`;
+                    return property.isRequired ? collectionMap : `${modelProperty} ? ${collectionMap} : ${UNDEFINED_STRING}`;
                 }
 
-                return `${modelProperty} ? ${property.type}.${TO_DTO_METHOD}(${modelProperty}) : ${UNDEFINED_STRING}`;
+                const valueMap = `${property.type}.${TO_DTO_METHOD}(${modelProperty})`;
+                return property.isRequired ? valueMap : `${modelProperty} ? ${valueMap} : ${UNDEFINED_STRING}`;
+            }
         }
 
         return modelProperty;
@@ -151,49 +171,56 @@ export class ObjectGenerator {
         switch (property.kind) {
             case PropertyKind.Date:
                 if (property.isCollection) {
-                    return `${dtoProperty} ? ${dtoProperty}.map(toDateIn) : ${ARRAY_STRING}`;
+                    const collectionMap = `${dtoProperty}.map(toDateIn)`;
+                    return property.isRequired ? collectionMap : `${dtoProperty} ? ${collectionMap} : ${ARRAY_STRING}`;
                 }
 
                 return `toDateIn(${dtoProperty})`;
 
             case PropertyKind.Guid:
                 if (property.isCollection) {
-                    return `${dtoProperty} ? ${dtoProperty}.map(x => new ${property.type}(x)) : ${ARRAY_STRING}`;
+                    const collectionMap = ` ${dtoProperty}.map(x => new ${property.type}(x))`;
+                    return property.isRequired ? collectionMap : `${dtoProperty} ? ${collectionMap} : ${ARRAY_STRING}`;
                 }
 
-                if (property.isNullable) {
+                if (property.isNullable && !property.isRequired) {
                     return `${dtoProperty} ? new ${property.type}(${dtoProperty}) : ${NULL_STRING}`;
                 }
 
                 return `new ${property.type}(${dtoProperty})`;
 
-            case PropertyKind.Identity:
+            case PropertyKind.Identity: {
                 if (property.isCollection) {
-                    return `${dtoProperty} ? ${dtoProperty}.map(x => new ${property.type}(x.id)) : ${ARRAY_STRING}`;
+                    const collectionMap = `${dtoProperty}.map(x => new ${property.type}(x.id))`;
+                    return property.isRequired ? collectionMap : `${dtoProperty} ? ${collectionMap} : ${ARRAY_STRING}`;
                 }
 
-                return `${dtoProperty} ? new ${property.type}(${dtoProperty}.id) : ${UNDEFINED_STRING}`;
+                const createValue = `new ${property.type}(${dtoProperty}.id)`;
+                return property.isRequired ? createValue : `${dtoProperty} ? ${createValue} : ${UNDEFINED_STRING}`;
+            }
 
-            case PropertyKind.Union:
+            case PropertyKind.Union: {
                 if (property.isCollection) {
-                    return `${dtoProperty} ? ${dtoProperty}.map(x => ${this.nameService.getClassName(
-                        property.type
-                    )}.${FROM_DTO_METHOD}(x)) : ${ARRAY_STRING}`;
+                    const collectionMap = `${dtoProperty}.map(x => ${this.nameService.getClassName(property.type)}.${FROM_DTO_METHOD}(x))`;
+                    return property.isRequired ? collectionMap : `${dtoProperty} ? ${collectionMap} : ${ARRAY_STRING}`;
                 }
 
-                return `${dtoProperty} ? ${this.nameService.getClassName(
-                    property.type
-                )}.${FROM_DTO_METHOD}(${dtoProperty}) : ${UNDEFINED_STRING}`;
+                const createValue = `${this.nameService.getClassName(property.type)}.${FROM_DTO_METHOD}(${dtoProperty})`;
+                return property.isRequired ? createValue : `${dtoProperty} ? ${createValue} : ${UNDEFINED_STRING}`;
+            }
 
-            case PropertyKind.Object:
+            case PropertyKind.Object: {
                 if (property.isCollection) {
-                    return `${dtoProperty} ? ${dtoProperty}.map(x => ${property.type}.${FROM_DTO_METHOD}(x)) : ${ARRAY_STRING}`;
+                    const collectionMap = `${dtoProperty}.map(x => ${property.type}.${FROM_DTO_METHOD}(x))`;
+                    return property.isRequired ? collectionMap : `${dtoProperty} ? ${collectionMap} : ${ARRAY_STRING}`;
                 }
 
-                return `${dtoProperty} ? ${property.type}.${FROM_DTO_METHOD}(${dtoProperty}) : ${UNDEFINED_STRING}`;
+                const valueMap = `${property.type}.${FROM_DTO_METHOD}(${dtoProperty})`;
+                return property.isRequired ? valueMap : `${dtoProperty} ? ${valueMap} : ${UNDEFINED_STRING}`;
+            }
 
             default:
-                if (property.isCollection) {
+                if (property.isCollection && !property.isRequired) {
                     return `${dtoProperty} ? ${dtoProperty} : ${ARRAY_STRING}`;
                 }
 

--- a/src/generators/utils/TypeSerializer.ts
+++ b/src/generators/utils/TypeSerializer.ts
@@ -18,7 +18,10 @@ export class TypeSerializer {
     public static fromInterfaceProperty(param: IInterfacePropertyModel): TypeSerializer {
         return new TypeSerializer({
             isCollection: param.isCollection,
-            isNullable: param.isNullable,
+            // TODO: by design object model in strong typed (c#) languages can combine isRequired=true and isNullable=true,
+            // but it's a strange for UI contract, so any required field will count as Non-Nullable
+            isNullable: !param.isRequired && param.isNullable,
+            isOptional: !param.isRequired,
             type: {
                 name: param.dtoType,
                 isInterface: true

--- a/src/generators/utils/typeOrUndefined.ts
+++ b/src/generators/utils/typeOrUndefined.ts
@@ -3,3 +3,7 @@ import { TYPES_NAMESPACE } from './consts';
 export function typeOrUndefined(type: string): string {
     return `${TYPES_NAMESPACE}.TypeOrUndefined<${type}>`;
 }
+
+export function publicFields(type: string): string {
+    return `${TYPES_NAMESPACE}.PublicFields<${type}>`;
+}

--- a/src/models/InterfaceModel.ts
+++ b/src/models/InterfaceModel.ts
@@ -3,6 +3,7 @@ export interface IInterfacePropertyModel {
     name: string;
     dtoType: string;
     isNullable: boolean;
+    isRequired: boolean;
 }
 
 export interface IInterfaceModel {

--- a/src/models/ObjectModel.ts
+++ b/src/models/ObjectModel.ts
@@ -2,8 +2,8 @@ import { IType } from './TypeModel';
 
 export interface IObjectPropertyModel extends IType {
     name: string;
-    isNullable: boolean;
     isCollection: boolean;
+    isRequired: boolean;
 }
 
 export interface IObjectModel {

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,7 +6,8 @@ export const defaultOptions: IOptions = {
     utilsRelativePath: '',
     url: 'https://localhost:5001/swagger/v1/swagger.json',
     withRequestOptions: false,
-    unstrictId: false
+    unstrictId: false,
+    withLegacyUndefineGeneration: false
 };
 
 export interface IOptions {
@@ -19,6 +20,7 @@ export interface IOptions {
     withRequestOptions: boolean;
     unstrictId: boolean;
     utilsRelativePath: string;
+    withLegacyUndefineGeneration: boolean;
 }
 
 export const pathOptions = {

--- a/src/services/ModelMappingService.ts
+++ b/src/services/ModelMappingService.ts
@@ -43,16 +43,17 @@ export class ModelMappingService {
             }
 
             if (this.typesGuard.isObject(schema)) {
+                const idFieldName = 'id';
                 if (this.isIdentity(schema)) {
                     identities.push({
                         name,
                         isNullable: false,
                         dtoType: this.nameService.getInterfaceName(name),
                         property: {
-                            ...this.typesService.getSimpleType(schema.properties['id'] as IOpenAPI3GuidSchema),
-                            isRequired: schema.required?.includes('id') ?? false,
+                            ...this.typesService.getSimpleType(schema.properties[idFieldName] as IOpenAPI3GuidSchema),
+                            isRequired: this.isRequiredField(schema, idFieldName),
                             isCollection: false,
-                            name: 'id',
+                            name: idFieldName,
                             isNullable: true
                         }
                     });
@@ -71,6 +72,10 @@ export class ModelMappingService {
             interfaces: this.getInterfaces(identities, objects).sort(sortBy((z) => z.name)),
             objects: objects.sort(sortBy((z) => z.name))
         };
+    }
+
+    protected isRequiredField(schema: IOpenAPI3ObjectSchema, fieldName: string): boolean {
+        return schema.required?.includes(fieldName) ?? false;
     }
 
     private toEnumModel(name: string, schema: IOpenAPI3EnumSchema): IEnumModel {
@@ -131,7 +136,7 @@ export class ModelMappingService {
 
         Object.entries(schema.properties)
             .filter(([name]) => !IGNORE_PROPERTIES.includes(name))
-            .forEach(([name, propertySchema]) => this.addProperty(model, name, propertySchema, schema.required?.includes(name) ?? false));
+            .forEach(([name, propertySchema]) => this.addProperty(model, name, propertySchema, this.isRequiredField(schema, name)));
 
         model.properties = model.properties.sort(sortBy((z) => z.name));
     }

--- a/src/services/ModelMappingService.ts
+++ b/src/services/ModelMappingService.ts
@@ -50,6 +50,7 @@ export class ModelMappingService {
                         dtoType: this.nameService.getInterfaceName(name),
                         property: {
                             ...this.typesService.getSimpleType(schema.properties['id'] as IOpenAPI3GuidSchema),
+                            isRequired: schema.required?.includes('id') ?? false,
                             isCollection: false,
                             name: 'id',
                             isNullable: true
@@ -127,28 +128,29 @@ export class ModelMappingService {
         if (!schema.properties) {
             return;
         }
+
         Object.entries(schema.properties)
             .filter(([name]) => !IGNORE_PROPERTIES.includes(name))
-            .forEach(([name, propertySchema]) => this.addProperty(model, name, propertySchema));
+            .forEach(([name, propertySchema]) => this.addProperty(model, name, propertySchema, schema.required?.includes(name) ?? false));
 
         model.properties = model.properties.sort(sortBy((z) => z.name));
     }
 
-    private addProperty(model: IObjectModel, name: string, schema: OpenAPI3Schema): void {
+    private addProperty(model: IObjectModel, name: string, schema: OpenAPI3Schema, isRequired: boolean): void {
         if (this.typesGuard.isSimple(schema)) {
-            model.properties.push(this.getSimpleProperty(name, schema));
+            model.properties.push(this.getSimpleProperty(name, schema, isRequired));
             return;
         }
 
         let property: IObjectPropertyModel | undefined;
         if (this.typesGuard.isCollection(schema)) {
             if (this.typesGuard.isSimple(schema.items)) {
-                property = this.getSimpleProperty(name, schema.items);
+                property = this.getSimpleProperty(name, schema.items, isRequired);
             } else if (this.typesGuard.isReference(schema.items)) {
-                property = this.getReferenceProperty(name, schema.items);
+                property = this.getReferenceProperty(name, schema.items, isRequired);
             }
             if (this.typesGuard.isOneOf(schema.items)) {
-                property = this.getUnionReferenceProperty(name, first(schema.items.oneOf));
+                property = this.getUnionReferenceProperty(name, first(schema.items.oneOf), isRequired);
             }
 
             if (property) {
@@ -159,11 +161,11 @@ export class ModelMappingService {
         }
 
         if (this.typesGuard.isReference(schema)) {
-            property = this.getReferenceProperty(name, schema);
+            property = this.getReferenceProperty(name, schema, isRequired);
         } else if (this.typesGuard.isAllOf(schema)) {
-            property = this.getReferenceProperty(name, first(schema.allOf));
+            property = this.getReferenceProperty(name, first(schema.allOf), isRequired);
         } else if (this.typesGuard.isOneOf(schema)) {
-            property = this.getUnionReferenceProperty(name, first(schema.oneOf));
+            property = this.getUnionReferenceProperty(name, first(schema.oneOf), isRequired);
         }
 
         if (property) {
@@ -207,16 +209,18 @@ export class ModelMappingService {
         });
     }
 
-    private getSimpleProperty(name: string, schema: OpenAPI3SimpleSchema): IObjectPropertyModel {
+    private getSimpleProperty(name: string, schema: OpenAPI3SimpleSchema, isRequired: boolean): IObjectPropertyModel {
         return {
             ...this.typesService.getSimpleType(schema),
             name,
             isCollection: false,
-            isNullable: Boolean(schema.nullable)
+            isRequired
+            // TODO: its always return from getSimpleType
+            //isNullable: Boolean(schema.nullable)
         };
     }
 
-    private getUnionReferenceProperty(name: string, schema: IOpenAPI3Reference): IObjectPropertyModel {
+    private getUnionReferenceProperty(name: string, schema: IOpenAPI3Reference, isRequired: boolean): IObjectPropertyModel {
         const schemaKey = this.openAPIService.getSchemaKey(schema);
 
         return {
@@ -224,12 +228,13 @@ export class ModelMappingService {
             isCollection: false,
             name: name,
             isNullable: false,
+            isRequired,
             type: this.nameService.getUnionName(schemaKey),
             dtoType: this.nameService.getInterfaceName(this.nameService.getUnionName(schemaKey))
         };
     }
 
-    private getReferenceProperty(name: string, schema: IOpenAPI3Reference): IObjectPropertyModel {
+    private getReferenceProperty(name: string, schema: IOpenAPI3Reference, isRequired: boolean): IObjectPropertyModel {
         const schemaKey = this.openAPIService.getSchemaKey(schema);
         const refSchema = this.openAPIService.getRefSchema(schema);
 
@@ -239,6 +244,7 @@ export class ModelMappingService {
                 isCollection: false,
                 name,
                 isNullable: false,
+                isRequired,
                 type: schemaKey,
                 dtoType: schemaKey
             };
@@ -252,6 +258,7 @@ export class ModelMappingService {
             name,
             isNullable: true,
             type: schemaKey,
+            isRequired,
             dtoType: this.nameService.getInterfaceName(schemaKey)
         };
     }
@@ -259,7 +266,15 @@ export class ModelMappingService {
     private getInterfaces(identities: IIdentityModel[], objects: ObjectModel[]): InterfaceModel[] {
         const interfaces: IInterfaceModel[] = identities.map((z) => ({
             name: this.nameService.getInterfaceName(z.name),
-            properties: [{ name: z.property.name, dtoType: z.property.dtoType, isCollection: false, isNullable: false }]
+            properties: [
+                {
+                    name: z.property.name,
+                    dtoType: z.property.dtoType,
+                    isRequired: z.property.isRequired,
+                    isCollection: false,
+                    isNullable: false
+                }
+            ]
         }));
 
         return interfaces.concat(
@@ -272,7 +287,8 @@ export class ModelMappingService {
                             name: x.name,
                             dtoType: x.dtoType,
                             isCollection: x.isCollection,
-                            isNullable: x.isNullable
+                            isNullable: x.isNullable,
+                            isRequired: x.isRequired
                         }))
                     };
                 } else {
@@ -282,7 +298,8 @@ export class ModelMappingService {
                             name: x.name,
                             dtoType: x.dtoType,
                             isCollection: x.isCollection,
-                            isNullable: x.isNullable
+                            isNullable: x.isNullable,
+                            isRequired: x.isRequired
                         }))
                     };
                 }

--- a/src/swagger/v3/schemas/object-schema.ts
+++ b/src/swagger/v3/schemas/object-schema.ts
@@ -3,6 +3,7 @@ import { OpenAPI3Schema } from './schema';
 
 export interface IOpenAPI3ObjectSchema extends IOpenAPI3BaseSchema {
     type: 'object';
+    required?: string[];
     properties: {
         [key: string]: OpenAPI3Schema;
     };

--- a/swagger.json
+++ b/swagger.json
@@ -723,6 +723,7 @@
       },
       "Product": {
         "type": "object",
+        "required": ["modifyDates", "categories","parentProduct", "status"],
         "properties": {
           "id": {
             "type": "string",
@@ -785,6 +786,9 @@
                 }
               ]
             }
+          },
+          "parentProduct": {
+            "$ref": "#/components/schemas/Product"
           },
           "status": {
             "allOf": [


### PR DESCRIPTION
Swashbuckle (SwaggerGenOptions) has option `NonNullableReferenceTypesAsRequired` (https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2036) that mark all non-nullable fields as required, so gengen can use it information to build more typed model without redundant undefined/nullable